### PR TITLE
chore: update next.js peer dependency range to support versions 15.0.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "vitest": "^2.1.5"
   },
   "peerDependencies": {
-    "next": "15.0.3",
+    "next": ">=15.0.3 <= 15.3.2",
     "redis": "4.7.0"
   },
   "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       next:
-        specifier: 15.0.3
+        specifier: '>=15.0.3 <= 15.3.2'
         version: 15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@commitlint/cli':

--- a/test/integration/next-app-15-3-2/pnpm-lock.yaml
+++ b/test/integration/next-app-15-3-2/pnpm-lock.yaml
@@ -444,7 +444,7 @@ packages:
   '@trieb.work/nextjs-turbo-redis-cache@file:../../..':
     resolution: {directory: ../../.., type: directory}
     peerDependencies:
-      next: 15.0.3
+      next: '>=15.0.3 <= 15.3.2'
       redis: 4.7.0
 
   '@tybys/wasm-util@0.9.0':


### PR DESCRIPTION
…3 through 15.3.2