### PR TITLE
fix: revalidate times for fetch entries from context is outdated

### DIFF
--- a/src/RedisStringsHandler.ts
+++ b/src/RedisStringsHandler.ts
@@ -467,7 +467,7 @@ export default class RedisStringsHandler {
     // TODO: implement expiration based on cacheControl.expire argument, -> probably relevant for cacheLife and "use cache" etc.: https://nextjs.org/docs/app/api-reference/functions/cacheLife
     // Constructing the expire time for the cache entry
     const revalidate =
-      // For fetch requests in newest versions, the revalidate context property never used, and instead the revalidate property of the passed-in data is used
+      // For fetch requests in newest versions, the revalidate context property is never used, and instead the revalidate property of the passed-in data is used
       (data.kind === 'FETCH' && data.revalidate) ||
       ctx.revalidate ||
       ctx.cacheControl?.revalidate;


### PR DESCRIPTION
For fetch requests in newest versions of Next.js, the revalidate context property is never used, and instead the revalidate property of the passed-in data is used

https://github.com/vercel/next.js/pull/76500