### PR TITLE
fix: serialize map<string,buffer> into json

### DIFF
--- a/src/RedisStringsHandler.ts
+++ b/src/RedisStringsHandler.ts
@@ -2,7 +2,7 @@ import { commandOptions, createClient, RedisClientOptions } from 'redis';
 import { SyncedMap } from './SyncedMap';
 import { DeduplicatedRequestHandler } from './DeduplicatedRequestHandler';
 import { debug } from './utils/debug';
-import { bufferReviver, bufferReplacer } from './utils/json';
+import { bufferAndMapReviver, bufferAndMapReplacer } from './utils/json';
 
 export type CommandOptions = ReturnType<typeof commandOptions>;
 export type Client = ReturnType<typeof createClient>;
@@ -405,7 +405,7 @@ export default class RedisStringsHandler {
 
       const cacheEntry: CacheEntry | null = JSON.parse(
         serializedCacheEntry,
-        bufferReviver,
+        bufferAndMapReviver,
       );
 
       debug(
@@ -606,7 +606,10 @@ export default class RedisStringsHandler {
         tags: ctx?.tags || [],
         value: data,
       };
-      const serializedCacheEntry = JSON.stringify(cacheEntry, bufferReplacer);
+      const serializedCacheEntry = JSON.stringify(
+        cacheEntry,
+        bufferAndMapReplacer,
+      );
 
       // pre seed data into deduplicated get client. This will reduce redis load by not requesting
       // the same value from redis which was just set.

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,12 +1,25 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function bufferReviver(_: string, value: any): any {
+export function bufferAndMapReviver(_: string, value: any): any {
   if (value && typeof value === 'object' && typeof value.$binary === 'string') {
     return Buffer.from(value.$binary, 'base64');
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof value.$map === 'object' &&
+    !!value.$map
+  ) {
+    return new Map(
+      Object.entries(value.$map).map(([key, value]) => {
+        const revivedValue = bufferAndMapReviver('', value);
+        return [key, revivedValue];
+      }),
+    );
   }
   return value;
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function bufferReplacer(_: string, value: any): any {
+export function bufferAndMapReplacer(_: string, value: any): any {
   if (Buffer.isBuffer(value)) {
     return {
       $binary: value.toString('base64'),
@@ -20,6 +33,16 @@ export function bufferReplacer(_: string, value: any): any {
   ) {
     return {
       $binary: Buffer.from(value.data).toString('base64'),
+    };
+  }
+  if (value && typeof value === 'object' && value instanceof Map) {
+    return {
+      $map: Object.fromEntries(
+        Array.from(value.entries()).map(([key, value]) => {
+          const replacedValue = bufferAndMapReplacer('', value);
+          return [key, replacedValue];
+        }),
+      ),
     };
   }
   return value;


### PR DESCRIPTION
I am running next.js 16 and getting an error for `segmentData` after getting the cache:
```
TypeError: p.segmentData.get is not a function
```

Debug-Logs showing this when setting the cache:
```
RedisStringsHandler.set() will set the following serializedCacheEntry
...
segmentData: Map(10) {
    '/_tree' => <Buffer 3a 48 4c 5b 22 2f 5f 6e 65 78 74 2f 73 74 61 74 69 63 2f 63 68 75 6e 6b 73 2f 31 64 38 64 61 38 63 30 63 62 66 33 61 37 35 37 2e 63 73 73 22 2c 22 73 ... 1052 more bytes>,
    '/_full' => <Buffer 31 3a 22 24 53 72 65 61 63 74 2e 66 72 61 67 6d 65 6e 74 22 0a 32 3a 49 5b 33 33 39 37 35 36 2c 5b 22 2f 5f 6e 65 78 74 2f 73 74 61 74 69 63 2f 63 68 ... 153653 more bytes>,
  ...
  }
...
```

`segmentData` is a Map<string,Buffer> and when serializing this, it becomes an empty object `{}`.

This PR fixes this by converting buffer into string and back.