### PR TITLE
chore: update GitHub Actions to use latest versions and improve npm p…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
   issues: write
   actions: write
   discussions: write
+  id-token: write
 
 jobs:
   release:
@@ -22,16 +23,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install
@@ -42,5 +44,4 @@ jobs:
       - name: Run Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub token for Semantic Release
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # NPM token for publishing
         run: npx semantic-release


### PR DESCRIPTION
…ublishing setup

- Update actions/checkout from v3 to v6
- Update actions/setup-node from v3 to v6
- Add id-token write permission for npm provenance
- Configure npm registry URL in setup-node
- Remove NPM_TOKEN secret (using GITHUB_TOKEN with provenance instead)