### PR TITLE
ci: restrict code coverage comments to internal pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,8 @@ jobs:
           PLAYWRIGHT_BASE_URL: http://localhost:3055
 
       - name: Code Coverage Comments
-        if: github.event_name == 'pull_request'
+      # only run for pull requests from this repository - so no problems for external PRs
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: kcjpop/coverage-comments@v2.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add repository check to prevent failures on external PRs
- Update condition to only run coverage comments for PRs from the same repository
- Add explanatory comment about external PR handling