### PR TITLE
fix: export CreateRedisStringsHandlerOptions type

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,13 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-describe('Example Test', () => {
-  it('should work correctly', () => {
-    console.log('TODO tests');
+import type { CreateRedisStringsHandlerOptions } from './index';
+
+describe('Public exports', () => {
+  it('exports CreateRedisStringsHandlerOptions type', () => {
+    const _typeCheck: CreateRedisStringsHandlerOptions = {
+      keyPrefix: 'test',
+    };
+
+    expect(_typeCheck.keyPrefix).toBe('test');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ import CachedHandler from './CachedHandler';
 export default CachedHandler;
 import RedisStringsHandler from './RedisStringsHandler';
 export { RedisStringsHandler };
+export type { CreateRedisStringsHandlerOptions } from './RedisStringsHandler';


### PR DESCRIPTION
Closes #41.

## Summary
Exports the `CreateRedisStringsHandlerOptions` type from the package entrypoint so consumers can import it directly:

```ts
import type { CreateRedisStringsHandlerOptions } from '@trieb.work/nextjs-turbo-redis-cache';
```

## Changes
- Re-export `CreateRedisStringsHandlerOptions` from `src/index.ts`.
- Add a small type-level test to ensure the export remains available.

## Testing
- `pnpm test` / commit hook ran `vitest` for the touched unit test file and it passed.