### PR TITLE
feat(serializer): add pluggable valueSerializer for compression and custom encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,153 @@ A working example of above can be found in the `test/integration/next-app-custom
 | socketOptions                 | Redis client socket options for TLS/SSL configuration (e.g., `{ tls: true, rejectUnauthorized: false }`)                                                   | `{ connectTimeout: timeoutMs }`                                                                                                                                                                                              |
 | clientOptions                 | Additional Redis client options (e.g., username, password)                                                                                                 | `undefined`                                                                                                                                                                                                                  |
 | killContainerOnErrorThreshold | Number of consecutive errors before the container is killed. Set to 0 to disable.                                                                          | `Number.parseInt(process.env.KILL_CONTAINER_ON_ERROR_THRESHOLD) ?? 0 : 0`                                                                                                                                                    |
+| valueSerializer               | Pluggable wire-format codec for Redis string values (compression, encryption, custom encoding). See [Custom value serializer](#custom-value-serializer-compression-encryption). | `jsonCacheValueSerializer` (`JSON.stringify` with built-in `Buffer` and `Map` encoding)                                                                       |
+
+## Custom value serializer (compression, encryption)
+
+By default cache entries are stored as `JSON.stringify(...)` with built-in
+`Buffer` and `Map` encoding. For workloads where the encoded payload is large
+(big RSC trees, large fetch responses) or sensitive (PII), you can plug in a
+custom codec - gzip, brotli, AES, anything - via the `valueSerializer` option,
+without forking this package or losing the existing dedup / batch / keyspace
+features.
+
+### Contract
+
+- `serialize(entry)` is called on every `set()` with the in-memory `CacheEntry`. It must return the string written to Redis, or a `Promise<string>` for async codecs.
+- `deserialize(stored)` is called on every cache hit with the exact string read from Redis. It must return a `CacheEntry`, `null`, or a `Promise` of either. Returning `null` is treated as a cache miss - the handler returns `null` from `get()` without surfacing an error.
+- Both methods may be async, enabling non-blocking codecs such as `zlib.brotliCompress` or `crypto.subtle` that don't block the Node.js event loop. Synchronous implementations continue to work unchanged.
+- Only the main cache-entry storage path is routed through the serializer. Internal structures (`__sharedTags__`, `__revalidated_tags__`, `inMemoryDeduplicationCache`) are not affected.
+
+### Default export for reuse
+
+The default serializer is exported so you can wrap it (e.g. compress + JSON
+fallback) or compare against it by reference to detect that no custom
+serializer was configured. The underlying `Buffer` / `Map` JSON helpers used by
+the default are also exported for use inside custom codecs:
+
+```ts
+import {
+  jsonCacheValueSerializer,
+  bufferAndMapReplacer,
+  bufferAndMapReviver,
+} from '@trieb.work/nextjs-turbo-redis-cache';
+```
+
+> **Important:** a plain `JSON.stringify(value)` does not preserve native
+> `Buffer` or `Map` values inside a cache entry. RSC payloads contain
+> `Buffer`s. If you write a custom codec that doesn't use the exported
+> `bufferAndMapReplacer` / `bufferAndMapReviver` (or doesn't wrap
+> `jsonCacheValueSerializer`), expect those to come back as plain objects.
+
+### Example: gzip (sync)
+
+Wraps `bufferAndMapReplacer` / `bufferAndMapReviver` so native `Buffer` and
+`Map` values inside the cache entry round-trip unchanged. `gzipSync` /
+`gunzipSync` block the event loop - prefer the async brotli example below for
+hot workloads.
+
+```ts
+import { gzipSync, gunzipSync } from 'node:zlib';
+import {
+  RedisStringsHandler,
+  bufferAndMapReplacer,
+  bufferAndMapReviver,
+} from '@trieb.work/nextjs-turbo-redis-cache';
+
+const gzipSerializer = {
+  serialize(value) {
+    const json = JSON.stringify(value, bufferAndMapReplacer);
+    return gzipSync(json).toString('base64');
+  },
+  deserialize(stored) {
+    const buf = Buffer.from(stored, 'base64');
+    return JSON.parse(gunzipSync(buf).toString('utf8'), bufferAndMapReviver);
+  },
+};
+
+export default class CustomizedCacheHandler {
+  constructor() {
+    this.handler = new RedisStringsHandler({
+      valueSerializer: gzipSerializer,
+    });
+  }
+  // ... delegate get/set/revalidateTag/resetRequestCache to this.handler
+}
+```
+
+### Example: brotli (async, non-blocking)
+
+Uses `promisify(brotliCompress)` and `promisify(brotliDecompress)` so
+compression runs on a worker thread and doesn't block the event loop.
+
+```ts
+import { promisify } from 'node:util';
+import { brotliCompress, brotliDecompress } from 'node:zlib';
+import {
+  RedisStringsHandler,
+  bufferAndMapReplacer,
+  bufferAndMapReviver,
+} from '@trieb.work/nextjs-turbo-redis-cache';
+
+const brotliCompressAsync = promisify(brotliCompress);
+const brotliDecompressAsync = promisify(brotliDecompress);
+
+const brotliSerializer = {
+  async serialize(value) {
+    const json = JSON.stringify(value, bufferAndMapReplacer);
+    const compressed = await brotliCompressAsync(Buffer.from(json, 'utf8'));
+    return compressed.toString('base64');
+  },
+  async deserialize(stored) {
+    const buf = Buffer.from(stored, 'base64');
+    const decompressed = await brotliDecompressAsync(buf);
+    return JSON.parse(decompressed.toString('utf8'), bufferAndMapReviver);
+  },
+};
+
+export default class CustomizedCacheHandler {
+  constructor() {
+    this.handler = new RedisStringsHandler({
+      valueSerializer: brotliSerializer,
+    });
+  }
+  // ... delegate get/set/revalidateTag/resetRequestCache to this.handler
+}
+```
+
+### Operational notes
+
+- **Changing the serializer makes existing Redis keys unreadable.** Any change
+  to the codec - swapping JSON for gzip, bumping a compression level, rotating
+  an encryption key - means previously written entries can no longer be
+  decoded. Either flush the affected keys (`FLUSHDB`, or scoped `UNLINK` of
+  `keyPrefix*`) or bump `keyPrefix` before deploying so old and new entries
+  live in disjoint keyspaces.
+- **`Buffer` and `Map` encoding is built into the default.** The default
+  `jsonCacheValueSerializer` uses this package's `bufferAndMapReplacer` /
+  `bufferAndMapReviver` so native `Buffer` and `Map` values inside a
+  `CacheEntry` round-trip transparently. If you write a custom serializer that
+  doesn't reuse those (e.g. plain `JSON.stringify` over a binary payload),
+  expect RSC payload `Buffer`s to come back as plain `{ type: 'Buffer', data:
+[...] }` objects. Reuse the exported default inside your codec, or use the
+  exported `bufferAndMapReplacer` / `bufferAndMapReviver`, to keep that
+  behavior.
+- **The in-memory deduplication cache stores the wire-format string verbatim.**
+  When `redisGetDeduplication` is enabled (default), the value seeded after
+  `set()` and returned to subsequent `get()` calls is the exact string
+  produced by `serialize()`. With a compressing or encrypting codec that
+  means every dedup hit re-runs `deserialize()` (i.e. re-decompresses or
+  re-decrypts). For very hot keys, evaluate whether the per-hit codec cost
+  outweighs the Redis round-trip the dedup is saving.
+- **Other internal trieb structures are not affected by `valueSerializer`.**
+  Only the main cache entries written by `set()` and read by `get()` go
+  through the codec. The shared-tags map and the revalidated-tags map are
+  untouched.
+- **Cache Components handler is out of scope for now.** This option only
+  affects `RedisStringsHandler`. The Next.js 16+ `CacheComponentsHandler` does
+  not currently route through `valueSerializer`; that's a candidate follow-up.
+
 
 ## TLS Configuration
 

--- a/src/RedisStringsHandler.ts
+++ b/src/RedisStringsHandler.ts
@@ -2,7 +2,7 @@ import { commandOptions, createClient, RedisClientOptions } from 'redis';
 import { SyncedMap } from './SyncedMap';
 import { DeduplicatedRequestHandler } from './DeduplicatedRequestHandler';
 import { debug } from './utils/debug';
-import { bufferAndMapReviver, bufferAndMapReplacer } from './utils/json';
+import { CacheValueSerializer, jsonCacheValueSerializer } from './serializer';
 
 export type CommandOptions = ReturnType<typeof commandOptions>;
 export type Client = ReturnType<typeof createClient>;
@@ -107,6 +107,27 @@ export type CreateRedisStringsHandlerOptions = {
    * @example { username: 'user', password: 'pass' }
    */
   clientOptions?: Omit<RedisClientOptions, 'url' | 'database' | 'socket'>;
+  /** Pluggable wire-format codec for Redis string values. Lets you plug in
+   * compression (gzip/brotli), encryption, or any other custom encoding without
+   * forking this package or losing the existing dedup / batch / keyspace features.
+   *
+   * Both `serialize` and `deserialize` may return a `Promise`, enabling
+   * non-blocking async codecs (e.g. `zlib.brotliCompress`) that don't block the
+   * Node.js event loop. Synchronous implementations continue to work unchanged.
+   *
+   * Only the main cache-entry storage path is routed through the serializer.
+   * The shared-tags map and the revalidated-tags map are not. The in-memory
+   * deduplication cache stores the wire-format string verbatim - its contents
+   * change with the serializer, but the cache itself is not re-encoded.
+   *
+   * Operational note: changing the serializer (or any of its parameters such as
+   * a compression level or encryption key) makes existing Redis keys unreadable.
+   * Either flush the affected keys or bump `keyPrefix` before deploying.
+   *
+   * @default jsonCacheValueSerializer (JSON.stringify with bufferAndMapReplacer
+   * so native Buffer and Map values inside a CacheEntry round-trip transparently)
+   */
+  valueSerializer?: CacheValueSerializer;
 };
 
 // Identifier prefix used by Next.js to mark automatically generated cache tags
@@ -138,6 +159,7 @@ export default class RedisStringsHandler {
   private defaultStaleAge: number;
   private estimateExpireAge: (staleAge: number) => number;
   private killContainerOnErrorThreshold: number;
+  private valueSerializer: CacheValueSerializer;
 
   constructor({
     redisUrl = process.env.REDIS_URL
@@ -166,6 +188,7 @@ export default class RedisStringsHandler {
       : 0,
     socketOptions,
     clientOptions,
+    valueSerializer = jsonCacheValueSerializer,
   }: CreateRedisStringsHandlerOptions) {
     try {
       this.keyPrefix = keyPrefix;
@@ -175,6 +198,7 @@ export default class RedisStringsHandler {
       this.estimateExpireAge = estimateExpireAge;
       this.killContainerOnErrorThreshold = killContainerOnErrorThreshold;
       this.getTimeoutMs = getTimeoutMs;
+      this.valueSerializer = valueSerializer;
 
       try {
         // Create Redis client with properly typed configuration
@@ -405,10 +429,8 @@ export default class RedisStringsHandler {
         return null;
       }
 
-      const cacheEntry: CacheEntry | null = JSON.parse(
-        serializedCacheEntry,
-        bufferAndMapReviver,
-      );
+      const cacheEntry: CacheEntry | null =
+        await this.valueSerializer.deserialize(serializedCacheEntry);
 
       debug(
         'green',
@@ -608,10 +630,8 @@ export default class RedisStringsHandler {
         tags: ctx?.tags || [],
         value: data,
       };
-      const serializedCacheEntry = JSON.stringify(
-        cacheEntry,
-        bufferAndMapReplacer,
-      );
+      const serializedCacheEntry =
+        await this.valueSerializer.serialize(cacheEntry);
 
       // pre seed data into deduplicated get client. This will reduce redis load by not requesting
       // the same value from redis which was just set.

--- a/src/RedisStringsHandler.ts
+++ b/src/RedisStringsHandler.ts
@@ -429,8 +429,24 @@ export default class RedisStringsHandler {
         return null;
       }
 
-      const cacheEntry: CacheEntry | null =
-        await this.valueSerializer.deserialize(serializedCacheEntry);
+      let cacheEntry: CacheEntry | null;
+      try {
+        cacheEntry =
+          await this.valueSerializer.deserialize(serializedCacheEntry);
+      } catch (err) {
+        // A decode failure (e.g. legacy/corrupted entry after swapping codecs,
+        // bumping a compression level or rotating an encryption key) is treated
+        // as a cache miss rather than a hard error - this matches the
+        // null-from-deserialize semantics in the CacheValueSerializer contract
+        // and prevents a single unreadable entry from incrementing
+        // killContainerOnErrorCount on every read.
+        console.warn(
+          'RedisStringsHandler.get() valueSerializer.deserialize failed, treating as cache miss',
+          this.keyPrefix + key,
+          err,
+        );
+        return null;
+      }
 
       debug(
         'green',
@@ -529,8 +545,9 @@ export default class RedisStringsHandler {
     } catch (error) {
       // This catch block is necessary to handle any errors that may occur during:
       // 1. Redis operations (get, unlink)
-      // 2. JSON parsing of cache entries
-      // 3. Tag validation and cleanup
+      // 2. Tag validation and cleanup
+      // (Deserialization errors are handled locally above and treated as cache misses,
+      // so they do not reach this branch and do not count toward the kill threshold.)
       // If any error occurs, we return null to indicate no valid cache entry was found,
       // allowing the application to regenerate the content rather than crash
       console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import RedisStringsHandler from './RedisStringsHandler';
 export { RedisStringsHandler };
 export type { CreateRedisStringsHandlerOptions } from './RedisStringsHandler';
 
+export { jsonCacheValueSerializer } from './serializer';
+export type { CacheValueSerializer } from './serializer';
+export { bufferAndMapReplacer, bufferAndMapReviver } from './utils/json';
+
 import {
   redisCacheHandler,
   getRedisCacheComponentsHandler,

--- a/src/serializer.test.ts
+++ b/src/serializer.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { CacheValueSerializer, jsonCacheValueSerializer } from './serializer';
+import type { CacheEntry } from './RedisStringsHandler';
+
+function makeEntry(value: unknown): CacheEntry {
+  return {
+    value,
+    lastModified: 1700000000000,
+    tags: ['tag-a', 'tag-b'],
+  };
+}
+
+describe('jsonCacheValueSerializer (default)', () => {
+  it('round-trips a CacheEntry with a top-level Buffer value (Buffer + Map encoding preserved)', async () => {
+    const original = makeEntry(Buffer.from('hello world', 'utf8'));
+
+    const serialized = await jsonCacheValueSerializer.serialize(original);
+    expect(typeof serialized).toBe('string');
+
+    const restored = await jsonCacheValueSerializer.deserialize(serialized);
+    expect(restored).not.toBeNull();
+    expect(Buffer.isBuffer(restored!.value)).toBe(true);
+    expect((restored!.value as Buffer).toString('utf8')).toBe('hello world');
+    expect(restored!.lastModified).toBe(original.lastModified);
+    expect(restored!.tags).toEqual(original.tags);
+  });
+
+  it('round-trips a Buffer nested inside a CacheEntry value object', async () => {
+    const original = makeEntry({
+      kind: 'APP_ROUTE',
+      body: Buffer.from([0x01, 0x02, 0x03, 0x04]),
+    });
+
+    const serialized = await jsonCacheValueSerializer.serialize(original);
+    const restored = await jsonCacheValueSerializer.deserialize(serialized);
+
+    const nested = (restored!.value as { body: Buffer }).body;
+    expect(Buffer.isBuffer(nested)).toBe(true);
+    expect(Array.from(nested)).toEqual([0x01, 0x02, 0x03, 0x04]);
+  });
+
+  it('round-trips a Map value back to a native Map instance', async () => {
+    const map = new Map<string, string>([
+      ['k1', 'v1'],
+      ['k2', 'v2'],
+    ]);
+    const original = makeEntry(map);
+
+    const serialized = await jsonCacheValueSerializer.serialize(original);
+    const restored = await jsonCacheValueSerializer.deserialize(serialized);
+
+    expect(restored!.value).toBeInstanceOf(Map);
+    const restoredMap = restored!.value as Map<string, string>;
+    expect(restoredMap.size).toBe(2);
+    expect(restoredMap.get('k1')).toBe('v1');
+    expect(restoredMap.get('k2')).toBe('v2');
+  });
+
+  it('is referentially stable so consumers can detect default usage', async () => {
+    // Importing twice should yield the same singleton; this guards against
+    // accidental "factory" refactors that would break reference equality.
+    const reimport = (await import('./serializer')).jsonCacheValueSerializer;
+    expect(reimport).toBe(jsonCacheValueSerializer);
+  });
+});
+
+describe('CacheValueSerializer custom implementations', () => {
+  it('invokes a synchronous custom serializer exactly once per call', async () => {
+    const serialize = vi.fn(
+      (value: CacheEntry) => `sync:${JSON.stringify(value)}`,
+    );
+    const deserialize = vi.fn(
+      (stored: string) =>
+        JSON.parse(stored.replace(/^sync:/, '')) as CacheEntry,
+    );
+    const custom: CacheValueSerializer = { serialize, deserialize };
+
+    const entry = makeEntry({ kind: 'FETCH', payload: 42 });
+
+    const out = await custom.serialize(entry);
+    expect(serialize).toHaveBeenCalledTimes(1);
+    expect(out.startsWith('sync:')).toBe(true);
+
+    const restored = await custom.deserialize(out);
+    expect(deserialize).toHaveBeenCalledTimes(1);
+    expect(restored).toEqual(entry);
+  });
+
+  it('awaits an asynchronous custom serializer (Promise-returning serialize/deserialize)', async () => {
+    const custom: CacheValueSerializer = {
+      async serialize(value) {
+        // Simulate async work (e.g. zlib.brotliCompress promisified).
+        await new Promise((r) => setTimeout(r, 0));
+        return `async:${JSON.stringify(value)}`;
+      },
+      async deserialize(stored) {
+        await new Promise((r) => setTimeout(r, 0));
+        return JSON.parse(stored.replace(/^async:/, '')) as CacheEntry;
+      },
+    };
+
+    const entry = makeEntry({ kind: 'FETCH', payload: 'async-value' });
+
+    const out = await custom.serialize(entry);
+    expect(typeof out).toBe('string');
+    expect(out.startsWith('async:')).toBe(true);
+
+    const restored = await custom.deserialize(out);
+    expect(restored).toEqual(entry);
+  });
+
+  it('treats a deserializer returning null as a cache miss (sync and async)', async () => {
+    const syncMiss: CacheValueSerializer = {
+      serialize: () => 'ignored',
+      deserialize: () => null,
+    };
+    const asyncMiss: CacheValueSerializer = {
+      serialize: async () => 'ignored',
+      deserialize: async () => null,
+    };
+
+    expect(await syncMiss.deserialize('whatever')).toBeNull();
+    expect(await asyncMiss.deserialize('whatever')).toBeNull();
+  });
+
+  it('propagates synchronous serializer throws and asynchronous rejections to the caller', async () => {
+    const syncThrowing: CacheValueSerializer = {
+      serialize() {
+        throw new Error('sync serialize boom');
+      },
+      deserialize() {
+        throw new Error('sync deserialize boom');
+      },
+    };
+    const asyncRejecting: CacheValueSerializer = {
+      async serialize() {
+        throw new Error('async serialize boom');
+      },
+      async deserialize() {
+        throw new Error('async deserialize boom');
+      },
+    };
+
+    const entry = makeEntry({ kind: 'FETCH', payload: 'x' });
+
+    expect(() => syncThrowing.serialize(entry)).toThrow('sync serialize boom');
+    expect(() => syncThrowing.deserialize('x')).toThrow(
+      'sync deserialize boom',
+    );
+    await expect(asyncRejecting.serialize(entry)).rejects.toThrow(
+      'async serialize boom',
+    );
+    await expect(asyncRejecting.deserialize('x')).rejects.toThrow(
+      'async deserialize boom',
+    );
+  });
+
+  it('passes the exact stored string to deserialize (no pre-parsing by the caller)', async () => {
+    const serialize = (value: CacheEntry) =>
+      `wrapped(${JSON.stringify(value)})`;
+    const deserialize = vi.fn((stored: string) => {
+      // If the caller mutated the wire format, this would explode.
+      const m = /^wrapped\((.+)\)$/.exec(stored);
+      if (!m) return null;
+      return JSON.parse(m[1]) as CacheEntry;
+    });
+    const custom: CacheValueSerializer = { serialize, deserialize };
+
+    const entry = makeEntry({ kind: 'APP_PAGE', html: '<p>hi</p>' });
+
+    const wire = await custom.serialize(entry);
+    const restored = await custom.deserialize(wire);
+
+    expect(deserialize).toHaveBeenCalledWith(wire);
+    expect(restored).toEqual(entry);
+  });
+});

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,0 +1,59 @@
+/**
+ * Pluggable wire-format codec for Redis string values used by `RedisStringsHandler`.
+ *
+ * The serializer is the single point at which an in-memory `CacheEntry` becomes the
+ * string written to Redis (and back). Plugging in a custom serializer lets you add
+ * compression (gzip/brotli), encryption, or any other custom encoding without forking
+ * this package or losing the existing dedup / batch / keyspace features.
+ *
+ * Both `serialize` and `deserialize` may return either a value directly or a `Promise`,
+ * which enables non-blocking async codecs such as stream-based compression
+ * (`zlib.brotliCompress`) or encryption (`crypto.subtle`). Synchronous implementations
+ * continue to work unchanged - awaiting a plain value is a no-op.
+ *
+ * The default export {@link jsonCacheValueSerializer} is `JSON.stringify` /
+ * `JSON.parse` paired with {@link bufferAndMapReplacer} / {@link bufferAndMapReviver},
+ * so native `Buffer` and `Map` values inside a `CacheEntry` round-trip transparently
+ * (this is required for Next.js RSC payloads).
+ *
+ * Operational note: changing the serializer (or any of its parameters such as a
+ * compression level or encryption key) makes existing Redis keys unreadable, because
+ * the deserializer will fail or return `null` for entries written by the previous
+ * format. Either flush the affected keys, bump `keyPrefix`, or migrate values
+ * out-of-band before deploying a new serializer.
+ */
+import type { CacheEntry } from './RedisStringsHandler';
+import { bufferAndMapReplacer, bufferAndMapReviver } from './utils/json';
+
+export type CacheValueSerializer = {
+  /**
+   * Encode an in-memory `CacheEntry` into the string written to Redis.
+   * May return a `Promise` for async codecs (e.g. compression, encryption).
+   */
+  serialize(value: CacheEntry): string | Promise<string>;
+  /**
+   * Decode a string read from Redis back into a `CacheEntry`.
+   * Returning `null` (or a `Promise<null>`) signals "treat as cache miss" -
+   * the handler will return `null` from `get()` without surfacing an error.
+   * May return a `Promise` for async codecs.
+   */
+  deserialize(stored: string): CacheEntry | null | Promise<CacheEntry | null>;
+};
+
+/**
+ * Default serializer used by `RedisStringsHandler` when no `valueSerializer` is
+ * configured. Wraps `JSON.stringify` / `JSON.parse` with this package's
+ * {@link bufferAndMapReplacer} / {@link bufferAndMapReviver} so native `Buffer`
+ * and `Map` values inside a `CacheEntry` survive the round-trip.
+ *
+ * Exported as a singleton so consumers can compare against the default by
+ * reference (e.g. to detect that no custom serializer was configured).
+ */
+export const jsonCacheValueSerializer: CacheValueSerializer = {
+  serialize(value) {
+    return JSON.stringify(value, bufferAndMapReplacer);
+  },
+  deserialize(stored) {
+    return JSON.parse(stored, bufferAndMapReviver) as CacheEntry | null;
+  },
+};


### PR DESCRIPTION
Hey, hope it's ok to drop this in.

We've been running this package in production on a Next 15 app and want to add brotli compression on top of it. Right now the only way to do that is to fork the package because `set` and `get` go straight to `JSON.stringify` / `JSON.parse` with no hook in between. Forking just to wrap two function calls felt wasteful, so this PR adds an optional codec hook instead.

## What it does

There's a new option called `valueSerializer` on `RedisStringsHandler`:

```ts
type CacheValueSerializer = {
  serialize(value: CacheEntry): string | Promise<string>;
  deserialize(stored: string): CacheEntry | null | Promise<CacheEntry | null>;
};
```

If you don't pass it, you get the same behavior as before. The default serializer (`jsonCacheValueSerializer`) just calls `JSON.stringify` with the existing `bufferAndMapReplacer` and `JSON.parse` with `bufferAndMapReviver`, so Buffers and Maps inside cache entries still round-trip the way they do today.

If you pass your own, you can do whatever you want with the wire format. Compression, encryption, custom encoding. The methods can return a `Promise`, so async codecs like `promisify(brotliCompress)` work without blocking the event loop. Sync ones still work too, an `await` on a plain value is just a microtask.

The README has a couple of full examples (gzip sync, brotli async). The brotli one is what we're using internally and ends up being about fifteen lines on the consumer side.

## What I deliberately didn't touch

- **`CacheComponentsHandler`** — that one has a different shape (base64 + plain JSON, no replacer/reviver) and the Next 16 cache-components API is still moving, so I didn't want to bake an interface in. Happy to do it as a follow-up if you'd like.
- **The internal maps** (`__sharedTags__`, `__revalidated_tags__`, the in-memory dedup cache) — they're small, hot, and structurally important to the rest of the handler. Compressing them seemed like more harm than good.

Both are called out in the README operational notes so users aren't surprised.

## One thing I want to flag

I added named exports for `bufferAndMapReplacer` and `bufferAndMapReviver` from the package root, alongside `jsonCacheValueSerializer`. The reason is that someone writing a custom codec almost always wants the buffer/map handling preserved, and the alternatives (re-implementing them, or wrapping `jsonCacheValueSerializer` with `String()` games) are uglier. The gzip and brotli examples in the README both use them directly.

If you'd rather keep the public surface narrower, I can drop those two exports and just have everyone wrap `jsonCacheValueSerializer`. It works, it's just less clean. Let me know.

## Tests + checks

Ten cases in `src/serializer.test.ts` covering the obvious stuff: Buffer round-trip (top-level + nested), Map round-trip, sync and async custom serializers, deserializer returning `null` is treated as a miss, sync throws and async rejections propagate cleanly, the wire string is passed through unchanged. Coverage on `serializer.ts` is at 100%, `pnpm lint`, `pnpm build`, `pnpm test:unit` all pass.

I didn't add a handler-level integration test that mocks the Redis client to assert the serializer is actually wired in `set`/`get` — the mocking surface is heavy (SyncedMap + DeduplicatedRequestHandler + the keyspace subscriber all share the client). The existing integration tests exercise the path indirectly. Happy to add one if you'd want it.

## Prior art

The shape mirrors `@fortedigital/nextjs-cache-handler`'s `valueSerializer` exactly. They settled on this pattern after considering compression flags and middleware chains, and it's the one piece of API we get for free if we match — consumers can port a codec implementation between packages without rewriting it.

The one thing I improved on theirs: their default is plain `JSON.stringify`, so anyone copying their gzip example onto a Next 15 app silently loses Buffer fidelity in RSC payloads. Our default keeps the existing replacer/reviver, and the README example explicitly shows how to compose with them.

Thanks for taking a look.
