### PR TITLE
ci: harden release pipeline against supply-chain attacks (post-1.12.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        # --ignore-scripts blocks lifecycle scripts of all dependencies to mitigate
+        # supply-chain attacks via compromised postinstall hooks.
+        run: pnpm install --ignore-scripts
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,17 @@ on:
     branches:
       - main
 
+# Default-deny: every job inherits read-only access. Jobs that need more
+# elevate explicitly via their own `permissions:` block (see `build` below).
 permissions:
-  contents: write
-  pull-requests: write
-  deployments: write
-  packages: write
-  statuses: write
-  issues: write
-  actions: write
-  discussions: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # Grant write access to pull request comments
+      contents: read # Required for actions/checkout
+      pull-requests: write # Required for the coverage-comments action on PRs
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,15 @@ on:
       - main
       - beta
       
+# Minimal permissions:
+#   contents:      semantic-release pushes the release commit + tag to the branch
+#   issues:        @semantic-release/github comments on referenced issues
+#   pull-requests: @semantic-release/github comments on referenced PRs
+#   id-token:      npm Trusted Publishing OIDC token exchange
 permissions:
   contents: write
-  pull-requests: write
-  deployments: write
-  packages: write
-  statuses: write
   issues: write
-  actions: write
-  discussions: write
+  pull-requests: write
   id-token: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Need full history so the post-release audit can diff against pre-release SHA.
+          fetch-depth: 0
+
+      - name: Capture pre-release SHA
+        id: pre
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
         run: corepack enable
@@ -35,18 +42,72 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts blocks lifecycle scripts (preinstall/install/postinstall/prepare)
+        # of all dependencies. This is the primary defence against supply-chain attacks
+        # injected via a compromised transitive dep's postinstall hook.
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
 
       - name: Build project
         run: pnpm build
 
+      - name: Verify working tree is clean before release
+        # If install/build silently modified tracked files, abort before semantic-release
+        # can include them in the release commit.
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Working tree is dirty before semantic-release. Aborting."
+            git status --short
+            git diff --stat
+            exit 1
+          fi
+
       - name: Run Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub token for Semantic Release
           NPM_CONFIG_PROVENANCE: 'true'
         run: pnpm exec semantic-release
+
+      - name: Audit semantic-release commit — fail if files outside allowlist were touched
+        env:
+          PRE_SHA: ${{ steps.pre.outputs.sha }}
+        run: |
+          # Allowlist must mirror the `assets` array in release.config.cjs.
+          # Any file outside this list being modified by the release run is suspicious
+          # and blocks the npm publish step below.
+          ALLOWED="package.json pnpm-lock.yaml CHANGELOG.md"
+
+          if [ "$(git rev-parse HEAD)" = "$PRE_SHA" ]; then
+            echo "semantic-release made no commit; nothing to audit."
+            exit 0
+          fi
+
+          echo "Auditing commits ${PRE_SHA}..HEAD"
+          CHANGED=$(git diff --name-only "${PRE_SHA}..HEAD")
+          echo "Files changed:"
+          printf '%s\n' "$CHANGED"
+
+          UNEXPECTED=""
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            match=false
+            for allowed in $ALLOWED; do
+              if [ "$file" = "$allowed" ]; then
+                match=true
+                break
+              fi
+            done
+            [ "$match" = false ] && UNEXPECTED="${UNEXPECTED}\n  ${file}"
+          done <<< "$CHANGED"
+
+          if [ -n "$UNEXPECTED" ]; then
+            printf '::error::semantic-release touched files outside the allowlist:%b\n' "$UNEXPECTED"
+            echo "::error::This may indicate a compromised dependency. Aborting publish."
+            exit 1
+          fi
+
+          echo "All changed files are within the allowlist."
 
       - name: Check if current version is already published
         id: version-check

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+.env
 coverage
 .DS_Store
 .idea
@@ -8,4 +9,3 @@ debug
 
 /.next/
 **/.next/
-config.bat

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "access": "public",
     "provenance": true
   },
+  "pnpm": {
+    "onlyBuiltDependencies": []
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",

--- a/test/integration/next-app-15-0-3/postcss.config.mjs
+++ b/test/integration/next-app-15-0-3/postcss.config.mjs
@@ -1,7 +1,3 @@
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
 const config = {
   plugins: ["@tailwindcss/postcss"],
 };

--- a/test/integration/next-app-15-3-2/postcss.config.mjs
+++ b/test/integration/next-app-15-3-2/postcss.config.mjs
@@ -1,7 +1,3 @@
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
 const config = {
   plugins: ["@tailwindcss/postcss"],
 };

--- a/test/integration/next-app-15-4-7/postcss.config.mjs
+++ b/test/integration/next-app-15-4-7/postcss.config.mjs
@@ -1,7 +1,3 @@
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
 const config = {
   plugins: ["@tailwindcss/postcss"],
 };

--- a/test/integration/next-app-16-0-3/postcss.config.mjs
+++ b/test/integration/next-app-16-0-3/postcss.config.mjs
@@ -1,7 +1,3 @@
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/test/integration/next-app-16-1-1-cache-components/postcss.config.mjs
+++ b/test/integration/next-app-16-1-1-cache-components/postcss.config.mjs
@@ -1,7 +1,3 @@
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/test/integration/next-app-16-1-1/postcss.config.mjs
+++ b/test/integration/next-app-16-1-1/postcss.config.mjs
@@ -1,7 +1,3 @@
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},


### PR DESCRIPTION
## Context

Release `1.12.0` (commit [`653e8ba`](https://github.com/trieb-work/nextjs-turbo-redis-cache/commit/653e8ba23e74f8de9ec1a5601f1e9c8d2893d180)) was published from a CI run that contained a **supply-chain attack**. A compromised transitive npm dependency executed during `pnpm install` and:

- Injected obfuscated JavaScript into every `test/integration/**/postcss.config.mjs`.
- Removed `.env` from `.gitignore` so future runs would commit secrets.
- Added `config.bat` to `.gitignore` to hide a dropper.

This PR cleans up the residue and adds layered defences so a comparable attack cannot land on `main` or be published to npm again.

## What changed

### 1. Reverts of the malicious commit's leftovers
- Restored `.env` in `.gitignore`.
- Removed the planted `config.bat` ignore entry.
- Removed the unused `createRequire` import header that the malware had inserted into all `postcss.config.mjs` files (the obfuscated payload itself was already removed in earlier `security:` commits).

### 2. Block the attack vector at install time

`@/Users/jannikzinkl/Documents/git/nextjs-turbo-redis-cache/package.json`
```json
"pnpm": { "onlyBuiltDependencies": [] }
```
Empty allowlist — pnpm will not run any dependency's lifecycle scripts. If a future legitimate dep needs one (e.g. `esbuild`, `sharp`), add only that name explicitly.

`@/Users/jannikzinkl/Documents/git/nextjs-turbo-redis-cache/.github/workflows/ci.yml` and `@/Users/jannikzinkl/Documents/git/nextjs-turbo-redis-cache/.github/workflows/release.yml`
```yaml
run: pnpm install --frozen-lockfile --ignore-scripts
```
Defence in depth: even if a contributor's local pnpm config drifts, CI never runs install-time scripts.

### 3. Defensive checks around `semantic-release`

In `release.yml`:
- **`fetch-depth: 0`** + capture pre-release SHA before any install/build runs.
- **Working-tree clean check before `semantic-release`** — aborts if `pnpm install` or `pnpm build` silently mutated tracked files (which is what the previous attack did).
- **Post-release file allowlist audit** — diffs `pre-release-sha..HEAD` and fails the publish step if anything outside `package.json`, `pnpm-lock.yaml`, `CHANGELOG.md` (the `assets` array of `release.config.cjs`) was modified. This is the last gate before npm publish.

### 4. Least-privilege workflow permissions

`release.yml` top-level `permissions:` reduced from 9 write scopes to the 4 actually used:
- `contents: write` — semantic-release commit + tag
- `issues: write` / `pull-requests: write` — `@semantic-release/github` comments
- `id-token: write` — npm Trusted Publishing OIDC

`ci.yml` top-level changed to `contents: read` (default-deny). The `build` job re-declares `contents: read` (for checkout) and `pull-requests: write` (for the coverage-comments action). All unused write scopes (`deployments`, `packages`, `statuses`, `actions`, `discussions`) were removed from both files.

## Files

| File | Change |
|---|---|
| `.gitignore` | revert malicious edits |
| `package.json` | add `pnpm.onlyBuiltDependencies: []` |
| `.github/workflows/ci.yml` | `--ignore-scripts`, default-deny permissions |
| `.github/workflows/release.yml` | `--ignore-scripts`, pre/post audits, minimal permissions |
| `test/integration/**/postcss.config.mjs` | remove dead `createRequire` import the malware inserted |

## Threat model — what this PR does and does not cover

| Vector | Status |
|---|---|
| Postinstall script in compromised dep | ✅ blocked by `--ignore-scripts` + empty `onlyBuiltDependencies` |
| Malicious code at `import` time during `pnpm build` mutating tracked files | ✅ caught by pre-release clean-tree check + post-release audit |
| Bot pushing to `main` outside allowlist | ✅ caught by post-release audit before npm publish (commit may still land on `main`; full prevention would require migrating to a PR-based release flow such as `release-please`) |
| Compromised GitHub Action (tag re-pointed to malicious commit) | ❌ not addressed — recommended follow-up: pin all actions by SHA + add Dependabot for `github-actions` |
| Job-level token compromised by in-process malware during build | ⚠ blast radius reduced by least-privilege; full mitigation would require splitting `release` into separate `build` / `release` / `publish` jobs |

## Follow-ups (not in this PR)

- Pin GitHub Actions by commit SHA and add Dependabot config for `npm` + `github-actions`.
- Split the `release` job into `build` (read-only) → `publish` (read + id-token) so a build-time compromise cannot push to git.
- Evaluate migrating from `semantic-release` to `release-please-action` (PR-based releases enable real `CODEOWNERS` enforcement and have a much smaller dependency surface).

## Notes for reviewers

- Two commits on this branch (`6b72ee6 test: signing` and `a28e912 test: signing v2`) are empty commits made while debugging local SSH commit signing. They are harmless but can be squashed/dropped during merge.
- After merge, verify the next release run on `main` succeeds — the audit step is new and should pass with semantic-release's normal output.
