### PR TITLE
test: stabilize CI integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: cd test/integration/${{ matrix.next-test-app }} && pnpm build
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm test:ci
         env:
           SKIP_BUILD: true
           NEXT_TEST_APP: ${{ matrix.next-test-app }}
@@ -121,3 +121,50 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # NPM token for publishing
         run: |
           npx semantic-release --dry-run
+
+  build-id-prefix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.8.0
+        with:
+          redis-version: '7'
+          redis-port: 6379
+
+      - name: Install redis-cli
+        run: sudo apt-get update && sudo apt-get install -y redis-tools
+
+      - name: Configure Redis Keyspace Notifications
+        run: redis-cli config set notify-keyspace-events Exe
+
+      - name: Install Integration Test Project
+        run: cd test/integration/next-app-15-4-7 && pnpm install
+
+      - name: Build Integration Test Project
+        run: cd test/integration/next-app-15-4-7 && pnpm build
+
+      - name: Run BUILD_ID integration test
+        run: pnpm test:integration:build-id-prefix

--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ To run all tests you can use the following command:
 pnpm build && pnpm test
 ```
 
+For CI, we use dedicated scripts:
+
+```bash
+pnpm test:ci
+pnpm test:integration:build-id-prefix
+```
+
 Folder layout / runners:
 
 - **Vitest** (unit + integration) lives in `src/**/*.test.ts(x)` and `test/**`.
@@ -246,6 +253,12 @@ To run integration tests you can use the following command:
 
 ```bash
 pnpm build && pnpm test:integration
+```
+
+To run the BUILD_ID integration test independently:
+
+```bash
+pnpm build && pnpm test:integration:build-id-prefix
 ```
 
 ### E2E tests (Playwright)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint": "eslint -c eslint.config.mjs --fix",
     "format": "prettier --write 'src/**/*.ts' 'src/*.ts'",
     "test": "vitest --coverage --config vite.config.ts",
+    "test:ci": "vitest --run --coverage --config vite.config.ts src/**/*.test.ts src/**/*.test.tsx test/integration/nextjs-cache-handler.integration.test.ts",
+    "test:integration:build-id-prefix": "vitest --run --coverage --config vite.config.ts test/integration/build-id-prefix.integration.test.ts",
     "test:ui": "vitest --ui  --config vite.config.ts",
     "test:unit": "vitest --config vite.config.ts src/**/*.test.ts src/**/*.test.tsx",
     "test:integration": "vitest --config vite.config.ts ./test/integration/nextjs-cache-handler.integration.test.ts",

--- a/test/integration/build-id-prefix.integration.test.ts
+++ b/test/integration/build-id-prefix.integration.test.ts
@@ -25,10 +25,29 @@ describe('BUILD_ID-based key prefix (Next handlers)', () => {
   let nextProcess: ChildProcessWithoutNullStreams | undefined;
   let redis: RedisClientType;
   let appDir: string;
+  let tempRootDir: string | undefined;
   let buildId: string;
 
   beforeAll(async () => {
-    appDir = path.join(__dirname, NEXT_APP);
+    const sourceAppDir = path.join(__dirname, NEXT_APP);
+    tempRootDir = fs.mkdtempSync(
+      path.join(__dirname, `.tmp-build-id-prefix-${NEXT_APP}-`),
+    );
+    appDir = path.join(tempRootDir, NEXT_APP);
+    fs.cpSync(sourceAppDir, appDir, {
+      recursive: true,
+      filter: (src) => {
+        const basename = path.basename(src);
+        return basename !== 'node_modules' && basename !== '.next';
+      },
+    });
+
+    const packageJsonPath = path.join(appDir, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const repoRoot = path.resolve(__dirname, '../..');
+    packageJson.dependencies['@trieb.work/nextjs-turbo-redis-cache'] =
+      `file:${repoRoot}`;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
     // Ensure clean env so BUILD_ID precedence kicks in
     delete (process.env as Record<string, string | undefined>).KEY_PREFIX;
@@ -82,6 +101,9 @@ describe('BUILD_ID-based key prefix (Next handlers)', () => {
       if (redis) await redis.quit();
     } finally {
       if (nextProcess) nextProcess.kill();
+      if (tempRootDir) {
+        fs.rmSync(tempRootDir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/test/integration/build-id-prefix.integration.test.ts
+++ b/test/integration/build-id-prefix.integration.test.ts
@@ -58,7 +58,10 @@ describe('BUILD_ID-based key prefix (Next handlers)', () => {
 
     // Install + build
     await new Promise<void>((resolve, reject) => {
-      const p = spawn('pnpm', ['install'], { cwd: appDir, stdio: 'inherit' });
+      const p = spawn('pnpm', ['install', '--no-frozen-lockfile'], {
+        cwd: appDir,
+        stdio: 'inherit',
+      });
       p.on('close', (code) =>
         code === 0 ? resolve() : reject(new Error('pnpm i failed')),
       );

--- a/test/integration/build-id-prefix.integration.test.ts
+++ b/test/integration/build-id-prefix.integration.test.ts
@@ -25,29 +25,10 @@ describe('BUILD_ID-based key prefix (Next handlers)', () => {
   let nextProcess: ChildProcessWithoutNullStreams | undefined;
   let redis: RedisClientType;
   let appDir: string;
-  let tempRootDir: string | undefined;
   let buildId: string;
 
   beforeAll(async () => {
-    const sourceAppDir = path.join(__dirname, NEXT_APP);
-    tempRootDir = fs.mkdtempSync(
-      path.join(__dirname, `.tmp-build-id-prefix-${NEXT_APP}-`),
-    );
-    appDir = path.join(tempRootDir, NEXT_APP);
-    fs.cpSync(sourceAppDir, appDir, {
-      recursive: true,
-      filter: (src) => {
-        const basename = path.basename(src);
-        return basename !== 'node_modules' && basename !== '.next';
-      },
-    });
-
-    const packageJsonPath = path.join(appDir, 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-    const repoRoot = path.resolve(__dirname, '../..');
-    packageJson.dependencies['@trieb.work/nextjs-turbo-redis-cache'] =
-      `file:${repoRoot}`;
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    appDir = path.join(__dirname, NEXT_APP);
 
     // Ensure clean env so BUILD_ID precedence kicks in
     delete (process.env as Record<string, string | undefined>).KEY_PREFIX;
@@ -58,10 +39,7 @@ describe('BUILD_ID-based key prefix (Next handlers)', () => {
 
     // Install + build
     await new Promise<void>((resolve, reject) => {
-      const p = spawn('pnpm', ['install', '--no-frozen-lockfile'], {
-        cwd: appDir,
-        stdio: 'inherit',
-      });
+      const p = spawn('pnpm', ['install'], { cwd: appDir, stdio: 'inherit' });
       p.on('close', (code) =>
         code === 0 ? resolve() : reject(new Error('pnpm i failed')),
       );
@@ -104,9 +82,6 @@ describe('BUILD_ID-based key prefix (Next handlers)', () => {
       if (redis) await redis.quit();
     } finally {
       if (nextProcess) nextProcess.kill();
-      if (tempRootDir) {
-        fs.rmSync(tempRootDir, { recursive: true, force: true });
-      }
     }
   });
 

--- a/test/integration/nextjs-cache-handler.integration.test.ts
+++ b/test/integration/nextjs-cache-handler.integration.test.ts
@@ -618,6 +618,7 @@ describe('Next.js Turbo Redis Cache Integration', () => {
         });
 
         it('Redis should have a key for the page which should have a TTL set to 28 days (2 * 14 days default revalidate time)', async () => {
+          await delay(REDIS_BACKGROUND_SYNC_DELAY);
           // check Redis keys
           const ttl = await redisClient.ttl(
             process.env.VERCEL_URL + '/pages/no-fetch/default-page',


### PR DESCRIPTION
## Summary
- split `build-id-prefix.integration.test.ts` into a dedicated CI job (`build-id-prefix`)
- keep matrix `build` job focused on unit tests + `nextjs-cache-handler.integration.test.ts` via `pnpm test:ci`
- remove temp-directory and lockfile-bypass workaround code from `build-id-prefix.integration.test.ts`
- keep the TTL flake quick fix (`REDIS_BACKGROUND_SYNC_DELAY`) in `nextjs-cache-handler.integration.test.ts`
- document the CI test split and new scripts in `README.md`

## Why
This keeps test isolation clean at the workflow level:
- no shared build artifact contention between `build-id-prefix` and the main integration suite
- no `--no-frozen-lockfile` workaround needed in tests
- deterministic CI behavior with explicit ownership per job

## Validation
- `pnpm test:integration:build-id-prefix`
- `NEXT_TEST_APP=next-app-15-4-7 SKIP_BUILD=true pnpm test:ci`
