### PR TITLE
fix: make redisCacheHandler lazy to avoid import-time Redis connection (#84)

### DIFF
--- a/src/CacheComponentsHandler.ts
+++ b/src/CacheComponentsHandler.ts
@@ -530,5 +530,34 @@ export function getRedisCacheComponentsHandler(
   return singletonHandler;
 }
 
-export const redisCacheHandler: CacheComponentsHandler =
-  getRedisCacheComponentsHandler();
+// Lazily resolve the default Cache Components handler.
+//
+// Constructing a RedisCacheComponentsHandler opens a Redis connection in its
+// constructor. Building the singleton at module-eval time therefore means that simply
+// *importing this package* — e.g. only for `RedisStringsHandler` (the legacy
+// `cacheHandler`), with Cache Components never enabled — eagerly connects to Redis,
+// defaulting to `redis://localhost:6379` when neither `REDIS_URL` nor `REDISHOST` is
+// set. In a deployment whose Redis is not on localhost that yields a non-stop
+// `RedisCacheComponentsHandler client error ECONNREFUSED 127.0.0.1:6379` reconnect
+// loop, and it also makes a consumer's later `getRedisCacheComponentsHandler(options)`
+// a no-op, because the singleton was already built with defaults (see #84).
+//
+// Defer construction to first use via a Proxy: importing the package never connects, a
+// consumer that configures the handler via `getRedisCacheComponentsHandler(options)`
+// before it is first used has that configuration honored, and a consumer that never
+// touches Cache Components never opens a Redis connection at all.
+export const redisCacheHandler: CacheComponentsHandler = new Proxy(
+  {} as CacheComponentsHandler,
+  {
+    get(_target, prop) {
+      const handler = getRedisCacheComponentsHandler();
+      const value = handler[prop as keyof CacheComponentsHandler];
+      return typeof value === 'function'
+        ? (value as (...args: unknown[]) => unknown).bind(handler)
+        : value;
+    },
+    has(_target, prop) {
+      return prop in RedisCacheComponentsHandler.prototype;
+    },
+  },
+);


### PR DESCRIPTION
## TL;DR

Importing this package eagerly constructs the Cache Components singleton at module-eval time, which opens a Redis connection as an *import side effect*. This makes the legacy `RedisStringsHandler`-only consumers connect to Redis whether they want Cache Components or not — defaulting to `localhost:6379` and spamming `ECONNREFUSED` in deployments whose Redis lives elsewhere — and it makes a later `getRedisCacheComponentsHandler(options)` a no-op. This PR defers construction to first use via a `Proxy`, so importing never connects. Fixes #84.

## Problem

The module ends with an eager export:

```ts
export const redisCacheHandler: CacheComponentsHandler = getRedisCacheComponentsHandler();
```

`getRedisCacheComponentsHandler()` builds a `RedisCacheComponentsHandler` whose constructor connects to Redis. Because this runs at module evaluation, **merely importing the package connects** — even for consumers that only use `RedisStringsHandler` (the legacy `cacheHandler`) and never enable Cache Components. With no `REDIS_URL`/`REDISHOST` set it defaults to `redis://localhost:6379`, producing a continuous

```
RedisCacheComponentsHandler client error Error: connect ECONNREFUSED 127.0.0.1:6379
```

reconnect loop in any environment whose Redis is not on localhost. It also defeats configuration: a consumer that calls `getRedisCacheComponentsHandler(options)` later gets the already-built default singleton, so their options are ignored. (See #84 for the full write-up, including the subclass/override use case the eager singleton blocks.)

## Fix

Defer construction to first property access via a `Proxy`:

```ts
export const redisCacheHandler: CacheComponentsHandler = new Proxy(
  {} as CacheComponentsHandler,
  {
    get(_target, prop) {
      const handler = getRedisCacheComponentsHandler();
      const value = handler[prop as keyof CacheComponentsHandler];
      return typeof value === 'function'
        ? (value as (...args: unknown[]) => unknown).bind(handler)
        : value;
    },
    has(_target, prop) {
      return prop in RedisCacheComponentsHandler.prototype;
    },
  },
);
```

- **Importing never connects.** Construction (and the Redis connection) happens on the first method call.
- **Configuration is honored.** A consumer that calls `getRedisCacheComponentsHandler(options)` before the handler is first used now has those options applied, because the singleton hasn't been built at import.
- **No public API change.** `redisCacheHandler` is still an importable value implementing `CacheComponentsHandler`.

### Why the `has` trap is needed (not dead code)

Next.js's implicit-tags path does an `in`-operator check on each registered cache handler:

```js
// next/dist/server/lib/cache-handlers/implicit-tags.js
if ('getExpiration' in cacheHandler) { /* register */ }
```

So `'getExpiration' in redisCacheHandler` is evaluated for real on the request path. The `has` trap answers from `RedisCacheComponentsHandler.prototype` — correct for all five interface methods — **without** constructing the handler. (Delegating `has` to a live handler would re-trigger the eager connection on every request; omitting it would make Next skip `getExpiration` registration and silently break tag expiration.)

## Validation

- `pnpm build` (tsup ESM+CJS+DTS) and `tsc --noEmit`: green.
- `pnpm test:unit`: 19/19 pass (identical to `main`).
- Runtime check against the built `dist`: importing the package produces **0** `RedisCacheComponentsHandler` connection errors (vs. the published `1.15.0` which produces them on import under the same conditions); the five interface methods all report `true` for `in` without triggering construction; and accessing a method *does* construct + connect on first use.

🤖 _This PR was written by Claude Code_
