### PR TITLE
fix: clear the readiness-timeout timer leaked on every cache operation

### DIFF
--- a/src/RedisStringsHandler.ts
+++ b/src/RedisStringsHandler.ts
@@ -348,21 +348,32 @@ export default class RedisStringsHandler {
         'assertClientIsReady called more than 10 times without being ready.',
       );
     }
-    await Promise.race([
-      Promise.all([
-        this.sharedTagsMap.waitUntilReady(),
-        this.revalidatedTagsMap.waitUntilReady(),
-      ]),
-      new Promise((_, reject) =>
-        setTimeout(() => {
-          reject(
-            new Error(
-              'assertClientIsReady: Timeout waiting for Redis maps to be ready',
-            ),
-          );
-        }, 30_000),
-      ),
-    ]);
+    let readyTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        Promise.all([
+          this.sharedTagsMap.waitUntilReady(),
+          this.revalidatedTagsMap.waitUntilReady(),
+        ]),
+        new Promise((_, reject) => {
+          readyTimeout = setTimeout(() => {
+            reject(
+              new Error(
+                'assertClientIsReady: Timeout waiting for Redis maps to be ready',
+              ),
+            );
+          }, 30_000);
+        }),
+      ]);
+    } finally {
+      // Always clear the timeout: once the race is won (the common case after
+      // the initial sync), the timer would otherwise stay pending for the full
+      // 30s. Timers capture the ambient async context (AsyncLocalStorage),
+      // so in a Next.js server every leaked timer pins the request's store —
+      // and with it the whole response object graph — for at least 30s on
+      // every single cache operation.
+      clearTimeout(readyTimeout);
+    }
     this.clientReadyCalls = 0;
     if (!this.client.isReady) {
       throw new Error(

--- a/test/vitest/unit/index.test.ts
+++ b/test/vitest/unit/index.test.ts
@@ -85,6 +85,34 @@ describe('RedisStringsHandler', () => {
     expect(res).toBeNull();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
+
+  it('does not leave the readiness timeout timer pending after an operation', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = new RedisStringsHandler({
+        redisUrl: 'redis://localhost:6379',
+        keyPrefix: 'test:',
+        database: 0,
+        getTimeoutMs: 1,
+        redisGetDeduplication: false,
+      });
+
+      const timersBefore = vi.getTimerCount();
+      await handler.get('missing-key', {
+        kind: 'APP_PAGE',
+        isRoutePPREnabled: false,
+        isFallback: false,
+      });
+
+      // assertClientIsReady() races waitUntilReady() against a 30s timeout;
+      // the timer must not stay pending once the race is settled, because
+      // pending timers retain the ambient async context (and with it, in a
+      // Next.js server, the whole per-request object graph).
+      expect(vi.getTimerCount()).toBe(timersBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('Public exports', () => {


### PR DESCRIPTION
## Problem

`RedisStringsHandler.assertClientIsReady()` guards every cache operation with a race:

```ts
await Promise.race([
  Promise.all([
    this.sharedTagsMap.waitUntilReady(),
    this.revalidatedTagsMap.waitUntilReady(),
  ]),
  new Promise((_, reject) =>
    setTimeout(() => {
      reject(new Error('assertClientIsReady: Timeout waiting for Redis maps to be ready'));
    }, 30_000),
  ),
]);
```

The `setTimeout` handle is never stored, so the timer cannot be cleared and stays pending for the full 30 s after the race is won — which, once the maps are synced, is on every single `get`/`set`/`revalidateTag` call.

A pending 30 s timer sounds cheap. Inside a Next.js request it is not: Node attaches the current async context to every timer (`AsyncLocalStorage` / `AsyncContextFrame` on Node ≥ 24), and in a standalone Next.js server that context pins the request's `workStore`, whose `afterContext` closure scope transitively references the entire response graph — `ServerResponse`, `IncomingMessage`, body streams, the zlib stream when compression is on, and upstream sockets. With several cache operations per render, every rendered page stays reachable for at least 30 s, and under sustained traffic closure scope chains keep graphs reachable considerably longer.

In our production deployment (Next 16.2.2 standalone, Node 24, 2 pods, ~350k req/day) this surfaced as linear RSS growth of ~0.5 GiB/day per pod, ending in an OOM kill at the 2 GiB cgroup limit every 2–3 days.

## Evidence

- Heap snapshot under load, memlab retainer analysis: 105 of 141 retained `ServerResponse` instances shared the path `Timeout[Symbol(kAsyncContextFrame)] → AsyncContextFrame → workStore → afterContext → … → ServerResponse`.
- Tracing `setTimeout` call sites: hundreds of live 30 000 ms timers, all created at `RedisStringsHandler.assertClientIsReady`.
- A/B load probe (300 SSR requests, double forced GC, then a `Runtime.queryObjects` census of live `ServerResponse` instances via the inspector):

| | retained after phase 1 | after phase 2 |
|---|---|---|
| 1.15.0 | 86 | 172 (accumulating) |
| 1.15.0 + this fix | 25 | 10 (draining) |

We are running this fix via a pnpm patch (staging today, production rollout in progress); under the same load probe the accumulation disappears entirely.

## Fix

Store the timer handle and clear it in `finally`. No behavior change: the 30 s rejection still fires if the maps never become ready.

The 10 s deduplication-cache deletion timers in `DeduplicatedRequestHandler` also capture the request context, but they are bounded by design and left untouched here.

## Test

Added a unit test next to the existing `RedisStringsHandler` tests: with fake timers, the pending-timer count must return to its pre-call value after a cache operation. It fails on current `main` (one 30 s timer left pending) and passes with the fix.
