### PR TITLE
ci: use GitHub App token for semantic-release release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           # Need full history so the post-release audit can diff against pre-release SHA.
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Capture pre-release SHA
         id: pre
@@ -65,7 +73,7 @@ jobs:
 
       - name: Run Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub token for Semantic Release
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }} # GitHub App token (bypasses required_signatures ruleset)
           NPM_CONFIG_PROVENANCE: 'true'
         run: pnpm exec semantic-release
 


### PR DESCRIPTION
## Problem
The org-wide `required_signatures` ruleset now rejects the semantic-release commit/tag push, because it's authored/signed by the default `GITHUB_TOKEN` (`github-actions[bot]`), which can never be a ruleset bypass actor.

## Fix
- Created a dedicated GitHub App `trwk-release-bot` (contents/issues/pull_requests: read&write) and installed it on this repo.
- Split `required_signatures` out of `Standard Protection Main` into its own org ruleset (`Required Signatures (release bot bypass)`), with the App as the only bypass actor.
- `non_fast_forward` and `deletion` remain enforced org-wide with **no bypass actors** (unchanged) — force-push/delete protection from the recent security incident is untouched.
- `release.yml` now mints a short-lived App installation token via `actions/create-github-app-token` and uses it for checkout + `semantic-release`.

This follows the [semantic-release 2026 recommendation](https://semantic-release.org/recipes/ci-configurations/github-actions/) of GitHub App auth over PATs/deploy keys for committing back to a protected branch.